### PR TITLE
use /usr/bin/env to find the bash preferred by the user

### DIFF
--- a/frank
+++ b/frank
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 curlUserAgent="-H \"User-Agent: Frank\""
 #first check bash version. needs to be 4+ to support associative arrays (used for keeping track of prefixes)
 associativeSupported=false


### PR DESCRIPTION
This commit allows Linux and Mac users to use their normal PATH settings to determine which installation of bash to use.
Especially for (mac) users like me who have an old version at /bin/bash but a newer version at an alternative location.
